### PR TITLE
single: 6.504s, dual: 3.329s

### DIFF
--- a/config.h
+++ b/config.h
@@ -12,5 +12,6 @@
 #define INT_PRIMITIVE 1
 #define PACK_W 1
 #define LAYER6_TANH_CPU 1
+#define REUSE_LAYER_FUNCTIONS 1
 
 #endif

--- a/hls.app
+++ b/hls.app
@@ -5,19 +5,19 @@
         <SimFlow askAgain="false" name="csim" csimMode="0" lastCsimMode="0"/>
     </Simulation>
     <files xmlns="">
-        <file name="../test_lenet1.cpp" sc="0" tb="1" cflags=" -I../external/hlslib/include  -fexceptions -Wno-unknown-pragmas" csimflags=" -Wno-unknown-pragmas" blackbox="false"/>
         <file name="../debug.h" sc="0" tb="1" cflags=" -Wno-unknown-pragmas" csimflags=" -Wno-unknown-pragmas" blackbox="false"/>
-        <file name="cnn_hls/utils.h" sc="0" tb="false" cflags="" csimflags="" blackbox="false"/>
-        <file name="cnn_hls/types.h" sc="0" tb="false" cflags="" csimflags="" blackbox="false"/>
-        <file name="cnn_hls/systolic_array.h" sc="0" tb="false" cflags="" csimflags="" blackbox="false"/>
-        <file name="cnn_hls/operators.h" sc="0" tb="false" cflags="" csimflags="" blackbox="false"/>
-        <file name="cnn_hls/memory.h" sc="0" tb="false" cflags="" csimflags="" blackbox="false"/>
-        <file name="cnn_hls/matrix.h" sc="0" tb="false" cflags="" csimflags="" blackbox="false"/>
-        <file name="cnn_hls/matmul.h" sc="0" tb="false" cflags="" csimflags="" blackbox="false"/>
-        <file name="cnn_hls/lenet.cpp" sc="0" tb="false" cflags="-Icnn_hls/external/hlslib/include -fexceptions" csimflags="" blackbox="false"/>
-        <file name="cnn_hls/im2col.h" sc="0" tb="false" cflags="" csimflags="" blackbox="false"/>
-        <file name="cnn_hls/config.h" sc="0" tb="false" cflags="" csimflags="" blackbox="false"/>
+        <file name="../test_lenet1.cpp" sc="0" tb="1" cflags=" -I../external/hlslib/include  -fexceptions -Wno-unknown-pragmas" csimflags=" -Wno-unknown-pragmas" blackbox="false"/>
         <file name="cnn_hls/cnn_functions.h" sc="0" tb="false" cflags="" csimflags="" blackbox="false"/>
+        <file name="cnn_hls/config.h" sc="0" tb="false" cflags="" csimflags="" blackbox="false"/>
+        <file name="cnn_hls/im2col.h" sc="0" tb="false" cflags="" csimflags="" blackbox="false"/>
+        <file name="cnn_hls/lenet.cpp" sc="0" tb="false" cflags="-Icnn_hls/external/hlslib/include -fexceptions" csimflags="" blackbox="false"/>
+        <file name="cnn_hls/matmul.h" sc="0" tb="false" cflags="" csimflags="" blackbox="false"/>
+        <file name="cnn_hls/matrix.h" sc="0" tb="false" cflags="" csimflags="" blackbox="false"/>
+        <file name="cnn_hls/memory.h" sc="0" tb="false" cflags="" csimflags="" blackbox="false"/>
+        <file name="cnn_hls/operators.h" sc="0" tb="false" cflags="" csimflags="" blackbox="false"/>
+        <file name="cnn_hls/systolic_array.h" sc="0" tb="false" cflags="" csimflags="" blackbox="false"/>
+        <file name="cnn_hls/types.h" sc="0" tb="false" cflags="" csimflags="" blackbox="false"/>
+        <file name="cnn_hls/utils.h" sc="0" tb="false" cflags="" csimflags="" blackbox="false"/>
     </files>
     <solutions xmlns="">
         <solution name="solution_Conv2d" status="inactive"/>

--- a/lenet.cpp
+++ b/lenet.cpp
@@ -1,4 +1,6 @@
+#include "config.h"
 #include "cnn_functions.h"
+#include "utils.h"
 
 void lenet1(
 		const minibatch_t *__restrict layer1_x, minibatch_t *__restrict layer1_y, const weight_t *__restrict layer1_weight, const weight_t *__restrict layer1_bias,
@@ -27,67 +29,76 @@ void lenet1(
 		const minibatch_t *__restrict layer7_x, minibatch_t *__restrict layer7_y, const weight_t *__restrict layer7_weight, const weight_t *__restrict layer7_bias,
 		uint_t layer7_in_features, uint_t layer7_out_features
 		) {
-#pragma HLS INTERFACE s_axilite port=return
 
-#pragma HLS INTERFACE m_axi port=layer1_x offset=slave bundle=layer1_data depth=784
-#pragma HLS INTERFACE m_axi port=layer1_y offset=slave bundle=layer1_data depth=2880
-#pragma HLS INTERFACE m_axi port=layer1_weight offset=slave bundle=layer1_param depth=125
-#pragma HLS INTERFACE m_axi port=layer1_bias offset=slave bundle=layer1_param depth=5
-#pragma HLS INTERFACE s_axilite port=layer1_input_size
-#pragma HLS INTERFACE s_axilite port=layer1_in_channels
-#pragma HLS INTERFACE s_axilite port=layer1_out_channels
-#pragma HLS INTERFACE s_axilite port=layer1_kernel_size
-#pragma HLS INTERFACE s_axilite port=layer1_stride
-#pragma HLS INTERFACE s_axilite port=layer1_padding
-#pragma HLS INTERFACE s_axilite port=layer1_dilation
+#define INTERFACE_M_AXI(port_value, bundle_value, depth_value) \
+		DO_PRAGMA(HLS INTERFACE m_axi port=port_value offset=slave bundle=bundle_value depth=depth_value)
+#define INTERFACE_S_AXILITE(port_value) \
+		DO_PRAGMA(HLS INTERFACE s_axilite port=port_value)
+#define INTERFACE_CONV(n, b, dx, dy, dw, db) INTERFACE_CONV_(n, b, dx, dy, dw, db)
+#define INTERFACE_CONV_(n, b, dx, dy, dw, db) \
+		INTERFACE_M_AXI(n##_x, b##_data, dx) \
+		INTERFACE_M_AXI(n##_y, b##_data, dy) \
+		INTERFACE_M_AXI(n##_weight, b##_param, dw) \
+		INTERFACE_M_AXI(n##_bias, b##_param, db) \
+		INTERFACE_S_AXILITE(n##_input_size) \
+		INTERFACE_S_AXILITE(n##_in_channels) \
+		INTERFACE_S_AXILITE(n##_out_channels) \
+		INTERFACE_S_AXILITE(n##_kernel_size) \
+		INTERFACE_S_AXILITE(n##_stride) \
+		INTERFACE_S_AXILITE(n##_padding) \
+		INTERFACE_S_AXILITE(n##_dilation)
+#define INTERFACE_POOL(n, b, dx, dy) INTERFACE_POOL_(n, b, dx, dy)
+#define INTERFACE_POOL_(n, b, dx, dy) \
+		INTERFACE_M_AXI(n##_x, b##_data, dx) \
+		INTERFACE_M_AXI(n##_y, b##_data, dy) \
+		INTERFACE_S_AXILITE(n##_channels) \
+		INTERFACE_S_AXILITE(n##_input_size) \
+		INTERFACE_S_AXILITE(n##_kernel_size) \
+		INTERFACE_S_AXILITE(n##_stride) \
+		INTERFACE_S_AXILITE(n##_padding) \
+		INTERFACE_S_AXILITE(n##_dilation)
+#define INTERFACE_LINE(n, b, dx, dy, dw) INTERFACE_LINE_(n, b, dx, dy, dw, dy)
+#define INTERFACE_LINE_(n, b, dx, dy, dw, db) \
+		INTERFACE_M_AXI(n##_x, b##_data, dx) \
+		INTERFACE_M_AXI(n##_y, b##_data, dy) \
+		INTERFACE_M_AXI(n##_weight, b##_param, dw) \
+		INTERFACE_M_AXI(n##_bias, b##_param, db) \
+		INTERFACE_S_AXILITE(n##_in_features) \
+		INTERFACE_S_AXILITE(n##_out_features)
+#define INTERFACE_MAPF(n, b, dx) INTERFACE_MAPF_(n, b, dx, dx)
+#define INTERFACE_MAPF_(n, b, dx, dy) \
+		INTERFACE_M_AXI(n##_x, b##_data, dx) \
+		INTERFACE_M_AXI(n##_y, b##_data, dy) \
+		INTERFACE_S_AXILITE(n##_features)
 
-#pragma HLS INTERFACE m_axi port=layer2_x offset=slave bundle=layer2_data depth=2880
-#pragma HLS INTERFACE m_axi port=layer2_y offset=slave bundle=layer2_data depth=720
-#pragma HLS INTERFACE s_axilite port=layer2_channels
-#pragma HLS INTERFACE s_axilite port=layer2_input_size
-#pragma HLS INTERFACE s_axilite port=layer2_kernel_size
-#pragma HLS INTERFACE s_axilite port=layer2_stride
-#pragma HLS INTERFACE s_axilite port=layer2_padding
-#pragma HLS INTERFACE s_axilite port=layer2_dilation
+#define BUNDLE1 layer1
+#define BUNDLE2 layer2
+#define BUNDLE5 layer5
 
-#pragma HLS INTERFACE m_axi port=layer3_x offset=slave bundle=layer3_data depth=720
-#pragma HLS INTERFACE m_axi port=layer3_y offset=slave bundle=layer3_data depth=320
-#pragma HLS INTERFACE m_axi port=layer3_weight offset=slave bundle=layer3_param depth=625
-#pragma HLS INTERFACE m_axi port=layer3_bias offset=slave bundle=layer3_param depth=5
-#pragma HLS INTERFACE s_axilite port=layer3_input_size
-#pragma HLS INTERFACE s_axilite port=layer3_in_channels
-#pragma HLS INTERFACE s_axilite port=layer3_out_channels
-#pragma HLS INTERFACE s_axilite port=layer3_kernel_size
-#pragma HLS INTERFACE s_axilite port=layer3_stride
-#pragma HLS INTERFACE s_axilite port=layer3_padding
-#pragma HLS INTERFACE s_axilite port=layer3_dilation
+#if LAYER6_TANH_CPU
+#define BUNDLE6 BUNDLE1
+#else
+#define BUNDLE6 layer6
+#endif
 
-#pragma HLS INTERFACE m_axi port=layer4_x offset=slave bundle=layer4_data depth=320
-#pragma HLS INTERFACE m_axi port=layer4_y offset=slave bundle=layer4_data depth=80
-#pragma HLS INTERFACE s_axilite port=layer4_channels
-#pragma HLS INTERFACE s_axilite port=layer4_input_size
-#pragma HLS INTERFACE s_axilite port=layer4_kernel_size
-#pragma HLS INTERFACE s_axilite port=layer4_stride
-#pragma HLS INTERFACE s_axilite port=layer4_padding
-#pragma HLS INTERFACE s_axilite port=layer4_dilation
+#if REUSE_LAYER_FUNCTIONS
+#define BUNDLE3 BUNDLE1
+#define BUNDLE4 BUNDLE2
+#define BUNDLE7 BUNDLE5
+#else
+#define BUNDLE3 layer3
+#define BUNDLE4 layer4
+#define BUNDLE7 layer7
+#endif
 
-#pragma HLS INTERFACE m_axi port=layer5_x offset=slave bundle=layer5_data depth=80
-#pragma HLS INTERFACE m_axi port=layer5_y offset=slave bundle=layer5_data depth=40
-#pragma HLS INTERFACE m_axi port=layer5_weight offset=slave bundle=layer5_param depth=3200
-#pragma HLS INTERFACE m_axi port=layer5_bias offset=slave bundle=layer5_param depth=40
-#pragma HLS INTERFACE s_axilite port=layer5_in_features
-#pragma HLS INTERFACE s_axilite port=layer5_out_features
-
-#pragma HLS INTERFACE m_axi port=layer6_x offset=slave bundle=layer6_data depth=40
-#pragma HLS INTERFACE m_axi port=layer6_y offset=slave bundle=layer6_data depth=40
-#pragma HLS INTERFACE s_axilite port=layer6_features
-
-#pragma HLS INTERFACE m_axi port=layer7_x offset=slave bundle=layer7_data depth=40
-#pragma HLS INTERFACE m_axi port=layer7_y offset=slave bundle=layer7_data depth=10
-#pragma HLS INTERFACE m_axi port=layer7_weight offset=slave bundle=layer7_param depth=400
-#pragma HLS INTERFACE m_axi port=layer7_bias offset=slave bundle=layer7_param depth=10
-#pragma HLS INTERFACE s_axilite port=layer7_in_features
-#pragma HLS INTERFACE s_axilite port=layer7_out_features
+	INTERFACE_S_AXILITE(return)
+	INTERFACE_CONV(layer1, BUNDLE1, 784, 2880, 125, 5)
+	INTERFACE_POOL(layer2, BUNDLE2, 2880, 720)
+	INTERFACE_CONV(layer3, BUNDLE3, 720, 320, 625, 5)
+	INTERFACE_POOL(layer4, BUNDLE4, 320, 80)
+	INTERFACE_LINE(layer5, BUNDLE5, 80, 40, 3200)
+	INTERFACE_MAPF(layer6, BUNDLE6, 40)
+	INTERFACE_LINE(layer7, BUNDLE7, 40, 10, 400)
 
 #pragma HLS DATAFLOW
 
@@ -96,16 +107,31 @@ void lenet1(
 	 */
 
 	{
-		cnn_Conv2d<0, BATCH_SIZE, value_t, PACK_W>(layer1_x, layer1_y, layer1_weight, layer1_bias, layer1_input_size, layer1_in_channels, layer1_out_channels, layer1_kernel_size, layer1_stride, layer1_padding, layer1_dilation);
-		cnn_Conv2d<0, BATCH_SIZE, value_t, PACK_W>(layer3_x, layer3_y, layer3_weight, layer3_bias, layer3_input_size, layer3_in_channels, layer3_out_channels, layer3_kernel_size, layer3_stride, layer3_padding, layer3_dilation);
+		for (uint_t i = 0; i < 2; i++) {
+#pragma HLS UNROLL factor=1
+			if (i == 0)
+				cnn_Conv2d<0, BATCH_SIZE, value_t, PACK_W>(layer1_x, layer1_y, layer1_weight, layer1_bias, layer1_input_size, layer1_in_channels, layer1_out_channels, layer1_kernel_size, layer1_stride, layer1_padding, layer1_dilation);
+			else
+				cnn_Conv2d<0, BATCH_SIZE, value_t, PACK_W>(layer3_x, layer3_y, layer3_weight, layer3_bias, layer3_input_size, layer3_in_channels, layer3_out_channels, layer3_kernel_size, layer3_stride, layer3_padding, layer3_dilation);
+		}
 	}
 	{
-		cnn_MaxPool2d<0, BATCH_SIZE, value_t>(layer2_x, layer2_y, layer2_channels, layer2_input_size, layer2_kernel_size, layer2_stride, layer2_padding, layer2_dilation);
-		cnn_MaxPool2d<0, BATCH_SIZE, value_t>(layer4_x, layer4_y, layer4_channels, layer4_input_size, layer4_kernel_size, layer4_stride, layer4_padding, layer4_dilation);
+		for (uint_t i = 0; i < 2; i++) {
+#pragma HLS UNROLL factor=1
+			if (i == 0)
+				cnn_MaxPool2d<0, BATCH_SIZE, value_t>(layer2_x, layer2_y, layer2_channels, layer2_input_size, layer2_kernel_size, layer2_stride, layer2_padding, layer2_dilation);
+			else
+				cnn_MaxPool2d<0, BATCH_SIZE, value_t>(layer4_x, layer4_y, layer4_channels, layer4_input_size, layer4_kernel_size, layer4_stride, layer4_padding, layer4_dilation);
+		}
 	}
 	{
-		cnn_Linear<0, BATCH_SIZE, value_t, PACK_W>(layer5_x, layer5_y, layer5_weight, layer5_bias, layer5_in_features, layer5_out_features);
-		cnn_Linear<0, BATCH_SIZE, value_t, PACK_W>(layer7_x, layer7_y, layer7_weight, layer7_bias, layer7_in_features, layer7_out_features);
+		for (uint_t i = 0; i < 2; i++) {
+#pragma HLS UNROLL factor=1
+			if (i == 0)
+				cnn_Linear<0, BATCH_SIZE, value_t, PACK_W>(layer5_x, layer5_y, layer5_weight, layer5_bias, layer5_in_features, layer5_out_features);
+			else
+				cnn_Linear<0, BATCH_SIZE, value_t, PACK_W>(layer7_x, layer7_y, layer7_weight, layer7_bias, layer7_in_features, layer7_out_features);
+		}
 	}
 #if !LAYER6_TANH_CPU
 	cnn_Tanh<0, BATCH_SIZE, value_t>(layer6_x, layer6_y, layer6_features);

--- a/utils.h
+++ b/utils.h
@@ -37,4 +37,6 @@ hlslib::DataPack<T, n> partial_pack(const hlslib::DataPack<T, m> src[n / m]) {
 	return ret;
 }
 
+#define DO_PRAGMA(x) _Pragma (#x)
+
 #endif


### PR DESCRIPTION
integrate ports (to reduce mux utilization and interconnect complexity)
reuse layer functions
fit two modules into pynq-z2